### PR TITLE
Add License section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,10 @@ Quick links:
   - [UBKG ETL Source Code](https://github.com/x-atlas-consortia/ubkg-etl)
   - [UBKG Neo4j Source Code](https://github.com/x-atlas-consortia/ubkg-neo4j)
   - [UBKG API Source Code](https://github.com/x-atlas-consortia/ubkg-api)
+
+## License
+
+This repository is dedicated to the public domain under the Creative Commons
+CC0 1.0 Universal Public Domain Dedication. You are free to copy, modify,
+distribute, and reuse the materials, even for commercial purposes, without
+asking permission. See [LICENSE.md](LICENSE.md) for the full dedication.


### PR DESCRIPTION
This adds a short "License" section near the end of the README so that the repository's licensing is visible to anyone browsing the project, without having to open the license file directly.

The section states that the repository is dedicated to the public domain under the Creative Commons CC0 1.0 Universal Public Domain Dedication and links to `LICENSE.md` for the full text. No other content or links in the README were changed.
